### PR TITLE
Path genérico para 'lib-linux64'

### DIFF
--- a/hemps8.5/build_env/makes/make_systemc
+++ b/hemps8.5/build_env/makes/make_systemc
@@ -36,7 +36,7 @@ all: $(HEMPS_TGT)
 
 $(HEMPS_TGT): $(ROUTER_TGT) $(PROCESSOR_TGT) $(DMNI_TGT) $(MEMORY_TGT) $(PE_TGT) $(TOP_TGT)
 	@printf "${COR}Generating %s ...${NC}\n" "$@"
-	g++ -I./ -o $@ $^ -L. -L/soft64/util/accelera/systemc/2.3.1/lib-linux64 -lsystemc
+	g++ -I./ -o $@ $^ -L. -L$(SYSTEMC)/lib-linux64 -lsystemc
 	
 $(TOP_TGT): $(TOP_SRC)
 	@printf "${COR}Compiling SystemC source: %s ...${NC}\n" "$(dir $<)$*.cpp"


### PR DESCRIPTION
Na linha 39, há um path absoluto para a pasta 'lib-linux64', provavelmente inserido por conta do ambiente original de desenvolvimento. Sugiro flexibilizá-lo, usando a variável de ambiente SYSTEMC criada no setup como referência.